### PR TITLE
Improve error handling for features not available in GHES

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -100,7 +100,7 @@ func NewCmdList() *cobra.Command {
 	}
 
 	// Determine default report file based on current timestamp; for more info see https://pkg.go.dev/time#pkg-constants
-	reportFileDefault := fmt.Sprintf("report-%s.csv", time.Now().Format("20060102150405"))
+	reportFileDefault := fmt.Sprintf("report-environments-%s.csv", time.Now().Format("20060102150405"))
 
 	// Configure flags for command
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -194,6 +194,10 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g *utils.APIGe
 			var Branches []string
 			var Apps []string
 
+			var envDeploymentProtectionPolicy data.DeploymentProtectionPolicy
+			var envVars data.EnvVariables
+			var envSecrets data.EnvSecret
+
 			for _, rules := range env.ProtectionRules {
 				zap.S().Debugf("Gathering Protection Rules for environment %s", env.Name)
 				if rules.Type == "wait_timer" {
@@ -241,51 +245,63 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g *utils.APIGe
 			zap.S().Debugf("Gathering Custom Deployment Protection Policies for environment %s", env.Name)
 			envProtectionResp, err := g.GetDeploymentProtectionRules(owner, singleRepo.Name, env.Name)
 			if err != nil {
-				zap.S().Error("Error raised in writing output", zap.Error(err))
-			}
-			var envDeploymentProtectionPolicy data.DeploymentProtectionPolicy
-			err = json.Unmarshal(envProtectionResp, &envDeploymentProtectionPolicy)
-			if err != nil {
-				return err
-			}
-			for _, apps := range envDeploymentProtectionPolicy.CustomDeploymentRules {
-				zap.S().Debugf("Gathering Custom DeploymentProtection Rules for environment %s", env.Name)
-				fmt.Println(apps)
-				var appList []string
-				appList = append(appList, strconv.Itoa(apps.PolicyID))
-				appList = append(appList, strconv.FormatBool(apps.Enabled))
-				appList = append(appList, strconv.Itoa(apps.App.IntegrationID))
-				appList = append(appList, apps.App.Slug)
-				AppLists := strings.Join(appList, ";")
-				Apps = append(Apps, AppLists)
+				if strings.Contains(err.Error(), "404: Not Found") {
+					zap.S().Debug("No custom deployment protection policies found for environment")
+				} else {
+					zap.S().Error("Error raised in writing output for deployment protection policies", zap.Error(err))
+				}
+			} else {
+
+				err = json.Unmarshal(envProtectionResp, &envDeploymentProtectionPolicy)
+				if err != nil {
+					return err
+				}
+				for _, apps := range envDeploymentProtectionPolicy.CustomDeploymentRules {
+					zap.S().Debugf("Gathering Custom DeploymentProtection Rules for environment %s", env.Name)
+					fmt.Println(apps)
+					var appList []string
+					appList = append(appList, strconv.Itoa(apps.PolicyID))
+					appList = append(appList, strconv.FormatBool(apps.Enabled))
+					appList = append(appList, strconv.Itoa(apps.App.IntegrationID))
+					appList = append(appList, apps.App.Slug)
+					AppLists := strings.Join(appList, ";")
+					Apps = append(Apps, AppLists)
+				}
 			}
 
 			//Get Secret Total Count
 			zap.S().Debugf("Gathering Count of Secrets for environment %s", env.Name)
 			envSecretResp, err := g.GetEnvironmentSecrets(singleRepo.DatabaseId, env.Name)
 			if err != nil {
-				zap.S().Error("Error raised in writing output", zap.Error(err))
-			}
-			var envSecrets data.EnvSecret
-			err = json.Unmarshal(envSecretResp, &envSecrets)
-			if err != nil {
-				return err
+				if strings.Contains(err.Error(), "404: Not Found") {
+					zap.S().Debug("No secrets found for environment")
+				} else {
+					zap.S().Error("Error raised in writing output for environment secrets", zap.Error(err))
+				}
+			} else {
+
+				err = json.Unmarshal(envSecretResp, &envSecrets)
+				if err != nil {
+					return err
+				}
 			}
 
 			//Get Variable total Count
 			zap.S().Debugf("Gathering Count of Variables for environment %s", env.Name)
 			envVarsResp, err := g.GetEnvironmentVariables(singleRepo.DatabaseId, env.Name)
 			if err != nil {
-				zap.S().Error("Error raised in writing output", zap.Error(err))
-			}
-			var envVars data.EnvVariables
-			err = json.Unmarshal(envVarsResp, &envVars)
-			if err != nil {
-				return err
-			}
+				if strings.Contains(err.Error(), "404: Not Found") {
+					zap.S().Debug("No variables found for environment")
+				} else {
+					zap.S().Error("Error raised in writing output for environment variables", zap.Error(err))
+				}
+			} else {
 
-			if err != nil {
-				zap.S().Error("Error raised in writing output", zap.Error(err))
+				err = json.Unmarshal(envVarsResp, &envVars)
+				if err != nil {
+					zap.S().Error("Error raised in writing output", zap.Error(err))
+					return err
+				}
 			}
 			err = csvWriter.Write([]string{
 				singleRepo.Name,

--- a/cmd/secrets/list/list.go
+++ b/cmd/secrets/list/list.go
@@ -100,7 +100,7 @@ func NewCmdList() *cobra.Command {
 	}
 
 	// Determine default report file based on current timestamp; for more info see https://pkg.go.dev/time#pkg-constants
-	reportFileDefault := fmt.Sprintf("report-%s.csv", time.Now().Format("20060102150405"))
+	reportFileDefault := fmt.Sprintf("report-secrets-%s.csv", time.Now().Format("20060102150405"))
 	// Configure flags for command
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.token, "token", "t", "", `GitHub Personal Access Token (default "gh auth token")`)
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")

--- a/cmd/variables/list/list.go
+++ b/cmd/variables/list/list.go
@@ -100,7 +100,7 @@ func NewCmdList() *cobra.Command {
 	}
 
 	// Determine default report file based on current timestamp; for more info see https://pkg.go.dev/time#pkg-constants
-	reportFileDefault := fmt.Sprintf("report-%s.csv", time.Now().Format("20060102150405"))
+	reportFileDefault := fmt.Sprintf("report-variables-%s.csv", time.Now().Format("20060102150405"))
 	// Configure flags for command
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.token, "token", "t", "", `GitHub Personal Access Token (default "gh auth token")`)
 	exportCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")

--- a/internal/utils/environments.go
+++ b/internal/utils/environments.go
@@ -159,11 +159,12 @@ func (g *APIGetter) GetDeploymentProtectionRules(owner string, repo string, env 
 	resp, err := g.restClient.Request("GET", url, nil)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("Body read error, %v", err)
+		log.Printf("Body response data read error, %v", err)
 	}
 	return responseData, err
 }

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -88,6 +88,7 @@ func (g *APIGetter) GetEnvironmentSecrets(repo_id int, env string) ([]byte, erro
 	resp, err := g.restClient.Request("GET", url, nil)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	responseData, err := io.ReadAll(resp.Body)

--- a/internal/utils/variables.go
+++ b/internal/utils/variables.go
@@ -49,6 +49,7 @@ func (g *APIGetter) GetEnvironmentVariables(repo_id int, env string) ([]byte, er
 	resp, err := g.restClient.Request("GET", url, nil)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	responseData, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
The changes mainly focus on improving error handling, and modifying the default report file names

Older versions of Github Enterprise Server don't have some of the newer functionality (ex. variables). This change allows so that if one of those functionality is not found in the API, the code will not panic and will instead return an error and will be logged but the code will continue to run.

Also, updated the default report file names to include the type of report being run (ex. environments, secrets, variables) to make it easier to identify the report file.


Error Handling Improvements:
* [`internal/utils/environments.go`](diffhunk://#diff-5caf7ebc979da24e239a2a57dd2f5de9fb5dfa78cd4229a037a8b019d110be3dR162-R167): Modified the `GetDeploymentProtectionRules` function to return an error if one occurs during the REST client request.
* [`internal/utils/secrets.go`](diffhunk://#diff-bec9ba8d7c0267fa1d0e2c8a1592e670087e23ce3ff98fb8c75870d7e0684678R91): Updated the `GetEnvironmentSecrets` function to return an error if one occurs during the REST client request.
* [`internal/utils/variables.go`](diffhunk://#diff-921cc57c1a801bf68caaa71ea07f19fbff22b26eb5cda8001460c4827f124d53R52): Updated the `GetEnvironmentVariables` function to return an error if one occurs during the REST client request.

Report File Naming Changes:
* [`cmd/list/list.go`](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205L103-R103): Modified the `NewCmdList` function to change the default report file name to include "environments".
* [`cmd/secrets/list/list.go`](diffhunk://#diff-6908532b7c5b33cc71fa3a196814625b3dc591975addf935deab818e6b01fe43L103-R103): Modified the `NewCmdList` function to change the default report file name to include "secrets".
* [`cmd/variables/list/list.go`](diffhunk://#diff-aeb5ba08f0ad31f13694cd43e6a2802867879e27b3671cb6b93470ee8ac2986dL103-R103): Modified the `NewCmdList` function to change the default report file name to include "variables".

Data Gathering Enhancements:
* [`cmd/list/list.go`](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R197-R200): In the `runCmdList` function, moved environment data variables next to other initialization variables, improved error handling for data gathering operations, and added conditions to handle "404: Not Found" errors specifically. [[1]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R197-R200) [[2]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205L244-R254) [[3]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205R270-L288)