### PR TITLE
Adding in linting and workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,79 @@
+name: PR Checks
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Build
+        run: go build -v .
+
+      - name: Run linting
+        uses: golangci/golangci-lint-action@v7.0.0
+        with:
+          version: latest
+          args: --timeout=5m
+
+      # - name: Run tests
+      #   run: |
+      #     set -o pipefail
+      #     go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic 2>&1 | tee test_output.log
+
+      # - name: Upload coverage report
+      #   uses: codecov/codecov-action@v5.4.2
+      #   with:
+      #     files: ./coverage.txt
+      #     fail_ci_if_error: false
+      #     verbose: true
+
+      # - name: Upload test artifacts
+      #   if: always()
+      #   uses: actions/upload-artifact@v4.6.2
+      #   with:
+      #     name: test-results
+      #     path: |
+      #       coverage.txt
+
+  markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: '16'
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+
+      - name: Lint Markdown files
+        run: |
+          markdownlint '**/*.md' \
+            --ignore node_modules \
+            --ignore '**/output/**' \
+            --config .markdownlint.yaml

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,25 @@
+# Example markdownlint configuration with all properties set to their default value
+
+# Default state for all rules
+default: true
+
+MD013:
+  # Number of characters
+  line_length: 100
+  # Number of characters for headings
+  heading_line_length: 100
+  # Number of characters for code blocks
+  code_block_line_length: 100
+  # Include code blocks
+  code_blocks: false
+  # Include tables
+  tables: false
+  # Include headings
+  headings: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+MD033:
+  # Allowed elements
+  allowed_elements: [code]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # gh-environments
 
-A GitHub `gh` [CLI](https://cli.github.com/) extension to list environments and their associated metadata for an organization and/or specific repositories. 
+[![GitHub Release](https://img.shields.io/github/v/release/katiem0/gh-environments?style=flat&logo=github)](https://github.com/katiem0/gh-environments/releases)
+[![PR Checks](https://github.com/katiem0/gh-environments/actions/workflows/main.yml/badge.svg)](https://github.com/katiem0/gh-environments/actions/workflows/main.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Report Card](https://goreportcard.com/badge/github.com/katiem0/gh-environments)](https://goreportcard.com/report/github.com/katiem0/gh-environments)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/katiem0/gh-environments)](https://go.dev/)
+
+A GitHub `gh` [CLI](https://cli.github.com/) extension to list environments and their
+associated metadata for an organization and/or specific repositories.
 
 ## Installation
 
 1. Install the `gh` CLI - see the [installation](https://github.com/cli/cli#installation) instructions.
 
 2. Install the extension:
+
    ```sh
    gh extension install katiem0/gh-environments
    ```
@@ -15,7 +23,8 @@ For more information: [`gh extension install`](https://cli.github.com/manual/gh_
 
 ## Usage
 
-The `gh-environments` extension supports `GitHub.com` and GitHub Enterprise Server, through the use of `--hostname` and the following commands:
+The `gh-environments` extension supports `GitHub.com` and GitHub Enterprise Server, through
+the use of `--hostname` and the following commands:
 
 ```sh
 $ gh environments -h
@@ -40,7 +49,6 @@ Use "environments [command] --help" for more information about a command.
 ### List Environments
 
 Environment metadata can be listed and written to a `csv` file for an organization or specific repository.
-
 
 ```sh
 $ gh environments list -h
@@ -71,17 +79,18 @@ The output `csv` file contains the following information:
 |`EnvironmentName`| The name of the repository specific environment. |
 |`AdminBypass`| `True`/`False` flag to indicate if administrators are allowed to bypass configured protection rules. |
 |`WaitTimer`| The an amount of time to wait before allowing deployments to proceed. |
-|`Reviewers`| Specified people or teams that have the ability to approve workflow runs when they access the environment. In the format `<UserOrTeam>;Name;ID` and reviewers delimited by `|` |
+|`Reviewers`| Specified people or teams that have the ability to approve workflow runs when they access the environment. In the format `<UserOrTeam>;Name;ID` and reviewers delimited by <code>&#124;</code> |
 |`PreventSelfReview` | Indicates if a Reviewer is able to approve/deny the workflow run on a specific environment |
 |`BranchPolicyType`| Indicates if the environment can only be deployed to specific branches. (Values: `protected`, `custom`, or `null`, where `null` indicates **any branch from the repo can deploy**.)|
-|`Branches`| If `BranchPolicyType = custom`, list of specific branch name patterns the environment deployment is limited to. In the format `Name;<BranchOrTag>` and policies delimited by `|`|
-|`CustomDeploymentProtectionPolicy`| Lists the custom deployment protection rules that are enabled for an environment. In the format: `PolicyID;Enabled;AppID;AppSlug` and policies delimited by `|`|
+|`Branches`| If `BranchPolicyType = custom`, list of specific branch name patterns the environment deployment is limited to. In the format `Name;<BranchOrTag>` and policies delimited by <code>&#124;</code>|
+|`CustomDeploymentProtectionPolicy`| Lists the custom deployment protection rules that are enabled for an environment. In the format: `PolicyID;Enabled;AppID;AppSlug` and policies delimited by <code>&#124;</code>|
 |`SecretsTotalCount`| The number of Actions secrets that are associated with the environment. |
 |`VariablesTotalCount`| The number of Actions variables that are associated with the environment. |
 
 ### Create Environments
 
-The `gh environments create` command will create environments from a `csv` file using `--from-file` following the format outlined in [`gh environments create`](#environment-create).
+The `gh environments create` command will create environments from a `csv` file
+using `--from-file` following the format outlined in [List Environments](#report-output).
 
 ```sh
 $ gh environments create -h
@@ -101,7 +110,8 @@ Global Flags:
       --help   Show help for command
 ```
 
-The `create` command utilizes the following fields in their given format but expects all headers listed [Report Output](#report-output): 
+The `create` command utilizes the following fields in their given format but expects all
+headers listed [Report Output](#report-output):
 
 | Field Name | Description |
 |:-----------|:------------|
@@ -109,14 +119,15 @@ The `create` command utilizes the following fields in their given format but exp
 |`EnvironmentName`| The name of the repository specific environment. |
 |`AdminBypass`| `True`/`False` flag to indicate if administrators are allowed to bypass configured protection rules. |
 |`WaitTimer`| The an amount of time to wait before allowing deployments to proceed. |
-|`Reviewers`| Specified people or teams that have the ability to approve workflow runs when they access the environment. In the format `<UserOrTeam>;Name;ID` and reviewers delimited by `|` |
+|`Reviewers`| Specified people or teams that have the ability to approve workflow runs when they access the environment. In the format `<UserOrTeam>;Name;ID` and reviewers delimited by <code>&#124;</code> |
 |`PreventSelfReview` | Indicates if a Reviewer is able to approve/deny the workflow run on a specific environment |
 |`BranchPolicyType`| Indicates if the environment can only be deployed to specific branches. (Values: `protected`, `custom`, or `null`, where `null` indicates **any branch from the repo can deploy**.)|
-|`Branches`| If `BranchPolicyType = custom`, list of specific branch name patterns the environment deployment is limited to. In the format `Name;<BranchOrTag>` and policies delimited by `|`|
+|`Branches`| If `BranchPolicyType = custom`, list of specific branch name patterns the environment deployment is limited to. In the format `Name;<BranchOrTag>` and policies delimited by <code>&#124;</code>|
 
 ### Environment Secrets
 
-The `gh environment secrets` command comprises of two subcommands, `list` and `create`, to access and create Environment specific Secrets.
+The `gh environment secrets` command comprises of two subcommands, `list` and `create`, to
+access and create Environment specific Secrets.
 
 ```sh
 $ gh environments secrets -h
@@ -136,7 +147,7 @@ Flags:
 Use "environments secrets [command] --help" for more information about a command.
 ```
 
-Both the `create` and `list` commands utilize the following fields: 
+Both the `create` and `list` commands utilize the following fields:
 
 | Field Name | Description |
 |:-----------|:------------|
@@ -150,10 +161,14 @@ Both the `create` and `list` commands utilize the following fields:
 
 #### Create Secrets
 
-The `gh environments secrets create` command will create secrets from a `csv` file using `--from-file` following the format outlined in [`gh environments secrets`](#environment-secrets).
+The `gh environments secrets create` command will create secrets from a `csv` file using
+`--from-file` following the format outlined in
+[`gh environments secrets`](#environment-secrets).
 
 >**Note**
-> The `SecretValue` specified in the `csv` file will be [encrypted using the associated `public key`](https://docs.github.com/en/actions/security-guides/encrypted-secrets) before the environment secret is created.
+> The `SecretValue` specified in the `csv` file will be
+> [encrypted using the associated `public key`](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+> before the environment secret is created.
 
 ```sh
 $ gh environments secrets create -h
@@ -175,11 +190,14 @@ Global Flags:
 
 #### List Secrets
 
-The `gh environments secrets list` command generates a `csv` report of environment specific secrets for the specified `<organization>` or `[repo ..]` list. If `[repo ...]` is specified, **secrets associated to environments across all repositories will be captured**. The report will contain secrets produces a `csv` report containing the fields outlined in [`gh environments secrets`](#environment-secrets).
+The `gh environments secrets list` command generates a `csv` report of environment specific
+secrets for the specified `<organization>` or `[repo ..]` list. If `[repo ...]` is specified,
+**secrets associated to environments across all repositories will be captured**. The report
+will contain secrets produces a `csv` report containing the fields outlined in
+[`gh environments secrets`](#environment-secrets).
 
 >**Note**
 > The `SecretValue` specified in the `csv` file will be left blank. **Secret values will NOT be extracted.**
-
 
 ```sh
 $ gh environments secrets list -h
@@ -199,10 +217,10 @@ Global Flags:
       --help   Show help for command
 ```
 
-
 ### Environment Variables
 
-The `gh environment variables` command comprises of two subcommands, `list` and `create`, to access and create Environment specific variables.
+The `gh environment variables` command comprises of two subcommands, `list` and `create`,
+to access and create Environment specific variables.
 
 ```sh
 $  gh environments variables -h
@@ -222,7 +240,7 @@ Flags:
 Use "environments variables [command] --help" for more information about a command.
 ```
 
-Both the `create` and `list` commands utilize the following fields: 
+Both the `create` and `list` commands utilize the following fields:
 
 | Field Name | Description |
 |:-----------|:------------|
@@ -236,9 +254,9 @@ Both the `create` and `list` commands utilize the following fields:
 
 #### Create Variables
 
-The `gh environments variables create` command will create variables from a `csv` file using `--from-file` following the format outlined in [`gh environments variables`](#environment-variables).
-
-
+The `gh environments variables create` command will create variables from a `csv` file using
+`--from-file` following the format outlined in
+[`gh environments variables`](#environment-variables).
 
 ```sh
 $ gh environments variables create -h
@@ -260,8 +278,11 @@ Global Flags:
 
 #### List Variables
 
-The `gh environments variables list` command generates a `csv` report of environment specific secrets for the specified `<organization>` or `[repo ..]` list. If `[repo ...]` is specified, **variables associated to environments across all repositories will be captured**. The report will contain variables produces a `csv` report containing the fields outlined in [`gh environments variables`](#environment-variables).
-
+The `gh environments variables list` command generates a `csv` report of environment specific
+secrets for the specified `<organization>` or `[repo ..]` list. If `[repo ...]` is specified,
+**variables associated to environments across all repositories will be captured**. The report
+will contain variables produces a `csv` report containing the fields outlined in
+[`gh environments variables`](#environment-variables).
 
 ```sh
 $ gh environments variables list -h

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -88,7 +88,9 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	createCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create environments from")
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	createCmd.MarkFlagRequired("from-file")
+	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
+		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+	}
 
 	return &createCmd
 }

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -90,6 +90,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
 		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+		return nil
 	}
 
 	return &createCmd

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -105,8 +105,11 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 		if err != nil {
 			zap.S().Errorf("Error arose opening environments csv file")
 		}
-		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				zap.S().Warnf("Error closing file: %v", closeErr)
+			}
+		}()
 
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -201,10 +201,10 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g *utils.APIGe
 
 			for _, rules := range env.ProtectionRules {
 				zap.S().Debugf("Gathering Protection Rules for environment %s", env.Name)
-				if rules.Type == "wait_timer" {
+				switch rules.Type {
+				case "wait_timer":
 					waitTimer = rules.WaitTimer
-
-				} else if rules.Type == "required_reviewers" {
+				case "required_reviewers":
 					zap.S().Debugf("Gathering Required Reviewers for environment %s", env.Name)
 					preventSelfReview = rules.PreventSelfReview
 					for _, reviewer := range rules.Reviewers {
@@ -215,7 +215,7 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g *utils.APIGe
 						reviewLists := strings.Join(reviewList, ";")
 						Reviewers = append(Reviewers, reviewLists)
 					}
-				} else if rules.Type == "branch_policy" {
+				case "branch_policy":
 					zap.S().Debugf("Gathering Branch Policies for environment %s", env.Name)
 					if env.DeploymentPolicy.CustomPolicies {
 						BranchPolicyType = "custom"

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -106,8 +106,11 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 		if err != nil {
 			zap.S().Errorf("Error arose opening secrets csv file")
 		}
-		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				zap.S().Warnf("Error closing file: %v", closeErr)
+			}
+		}()
 
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -91,6 +91,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
 		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+		return nil
 	}
 
 	return &createCmd

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -89,7 +89,9 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	createCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create secrets from")
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	createCmd.MarkFlagRequired("from-file")
+	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
+		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+	}
 
 	return &createCmd
 }

--- a/cmd/variables/create/create.go
+++ b/cmd/variables/create/create.go
@@ -106,8 +106,11 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter) error {
 		if err != nil {
 			zap.S().Errorf("Error arose opening variables csv file")
 		}
-		// remember to close the file at the end of the program
-		defer f.Close()
+		defer func() {
+			if closeErr := f.Close(); closeErr != nil {
+				zap.S().Warnf("Error closing file: %v", closeErr)
+			}
+		}()
 
 		// read csv values using csv.Reader
 		csvReader := csv.NewReader(f)

--- a/cmd/variables/create/create.go
+++ b/cmd/variables/create/create.go
@@ -91,6 +91,7 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
 	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
 		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+		return nil
 	}
 
 	return &createCmd

--- a/cmd/variables/create/create.go
+++ b/cmd/variables/create/create.go
@@ -89,7 +89,9 @@ func NewCmdCreate() *cobra.Command {
 	createCmd.PersistentFlags().StringVarP(&cmdFlags.hostname, "hostname", "", "github.com", "GitHub Enterprise Server hostname")
 	createCmd.Flags().StringVarP(&cmdFlags.fileName, "from-file", "f", "", "Path and Name of CSV file to create variables from")
 	createCmd.PersistentFlags().BoolVarP(&cmdFlags.debug, "debug", "d", false, "To debug logging")
-	createCmd.MarkFlagRequired("from-file")
+	if err := createCmd.MarkFlagRequired("from-file"); err != nil {
+		zap.S().Errorf("Error marking flag 'from-file' as required: %v", err)
+	}
 
 	return &createCmd
 }

--- a/internal/utils/environments.go
+++ b/internal/utils/environments.go
@@ -16,7 +16,11 @@ func (g *APIGetter) GetRepoEnvironments(owner string, repo string) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("HTTP error for URL %s: %v", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body from URL %s: %w", url, err)
@@ -30,7 +34,11 @@ func (g *APIGetter) GetDeploymentBranchPolicies(owner string, repo string, env s
 	if err != nil {
 		return nil, fmt.Errorf("HTTP error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
@@ -110,12 +118,13 @@ func CreateEnvironmentData(environment data.ImportedEnvironment) *data.CreateEnv
 		}
 		createReviewers = append(createReviewers, cr)
 	}
-	if environment.DeploymentPolicy == "protected" {
+	switch environment.DeploymentPolicy {
+	case "protected":
 		deploymentPolicy = &data.DeploymentPolicy{
 			ProtectedBranches: true,
 			CustomPolicies:    false,
 		}
-	} else if environment.DeploymentPolicy == "custom" {
+	case "custom":
 		deploymentPolicy = &data.DeploymentPolicy{
 			ProtectedBranches: false,
 			CustomPolicies:    true,
@@ -138,7 +147,11 @@ func (g *APIGetter) CreateEnvironment(owner string, repo string, env string, dat
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }
 
@@ -149,7 +162,11 @@ func (g *APIGetter) CreateDeploymentBranches(owner string, repo string, env stri
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }
 
@@ -160,7 +177,11 @@ func (g *APIGetter) GetDeploymentProtectionRules(owner string, repo string, env 
 		log.Printf("Body read error, %v", err)
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body response data read error, %v", err)

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -19,7 +19,11 @@ func (g *APIGetter) CreateEnvironmentSecret(owner string, repo string, env strin
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }
 
@@ -72,7 +76,11 @@ func (g *APIGetter) GetEnvironmentPublicKey(owner string, repo string, env strin
 	if err != nil {
 		log.Printf("Body read error, %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)
@@ -87,7 +95,11 @@ func (g *APIGetter) GetEnvironmentSecrets(owner string, repo string, env string)
 		log.Printf("Body read error, %v", err)
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)

--- a/internal/utils/variables.go
+++ b/internal/utils/variables.go
@@ -16,7 +16,11 @@ func (g *APIGetter) CreateEnvironmentVariables(owner string, repo string, env st
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	return err
 }
 
@@ -51,7 +55,11 @@ func (g *APIGetter) GetEnvironmentVariables(owner string, repo string, env strin
 		log.Printf("Body read error, %v", err)
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("Error closing response body: %v", closeErr)
+		}
+	}()
 	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Body read error, %v", err)


### PR DESCRIPTION
### CI/CD Enhancements:
* Added a new GitHub Actions workflow (`.github/workflows/main.yml`) to perform build, test, and linting checks for Go code, as well as markdown linting for `.md` files. Some steps, such as test execution and artifact uploads, are currently commented out.

### Documentation Improvements:
* Updated `README.md` with badges for release, license, CI status, and Go report, along with improved formatting for long lines and table entries. Updated references to CSV file formats and clarified usage instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R27) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R93) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R130) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R171) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R259)
* Added a markdown linting configuration file (`.markdownlint.yaml`) to enforce consistent formatting, including line length limits and allowed elements.

### Code Improvements:
* Enhanced error handling for the `MarkFlagRequired` method in the `create` commands for environments, secrets, and variables by logging errors using `zap.S().Errorf`. [[1]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8L91-R93) [[2]](diffhunk://#diff-404795ca85ebe483d9a5f3ca9f357e1d35739b2a78fc8e63fbc66addc1328c69L92-R94) [[3]](diffhunk://#diff-e8ecb8be36469000dfd988d841425467f9563a52e37412fc9b7364288aba053bL92-R94)

closes #11 